### PR TITLE
fix homebrew warning.

### DIFF
--- a/Formula/unox.rb
+++ b/Formula/unox.rb
@@ -7,7 +7,7 @@ class Unox < Formula
   sha256 '163668398356619d0b422f7e067836754d6eae6bf63058bac3f4c7c70182e837'
   revision 1
   depends_on :python => :recommended if MacOS.version <= :snow_leopard
-  depends_on :python3 => :optional
+  depends_on "python3" => :optional
 
   resource 'watchdog' do
     url 'https://pypi.python.org/packages/54/7d/c7c0ad1e32b9f132075967fc353a244eb2b375a3d2f5b0ce612fd96e107e/watchdog-0.8.3.tar.gz'


### PR DESCRIPTION
fix homebrew warning. issue #2

```
Warning: Calling 'depends_on :python3' is deprecated!
Use 'depends_on "python3"' instead.
/usr/local/Homebrew/Library/Taps/eugenmayer/homebrew-dockersync/Formula/unox.rb:10:in
`<class:Unox>'
Please report this to the eugenmayer/dockersync tap!
```