### PR TITLE
Fix syntax error

### DIFF
--- a/Formula/unox.rb
+++ b/Formula/unox.rb
@@ -6,7 +6,7 @@ class Unox < Formula
   head 'https://github.com/hnsl/unox.git', :using => :git, :revision => '0.2.0'
   sha256 '163668398356619d0b422f7e067836754d6eae6bf63058bac3f4c7c70182e837'
   revision 1
-  depends_on "python@2" =>
+  depends_on "python@2"
 
   resource 'watchdog' do
     url 'https://pypi.python.org/packages/54/7d/c7c0ad1e32b9f132075967fc353a244eb2b375a3d2f5b0ce612fd96e107e/watchdog-0.8.3.tar.gz'


### PR DESCRIPTION
```
Error: Failed to import: /usr/local/Homebrew/Library/Taps/eugenmayer/homebrew-dockersync/Formula/unox.rb
unox: /usr/local/Homebrew/Library/Taps/eugenmayer/homebrew-dockersync/Formula/unox.rb:11: syntax error, unexpected tSTRING_BEG, expecting keyword_do or '{' or '('
  resource 'watchdog' do
            ^
/usr/local/Homebrew/Library/Taps/eugenmayer/homebrew-dockersync/Formula/unox.rb:11: syntax error, unexpected keyword_do_block, expecting keyword_end
/usr/local/Homebrew/Library/Taps/eugenmayer/homebrew-dockersync/Formula/unox.rb:34: syntax error, unexpected keyword_end, expecting end-of-input
```

This PR fixes above error.