### PR TITLE
Call virtualenv_install_with_resources with `:using => "python@3"

### DIFF
--- a/Formula/unox.rb
+++ b/Formula/unox.rb
@@ -21,7 +21,7 @@ class Unox < Formula
   include Language::Python::Virtualenv
 
   def install
-    virtualenv_install_with_resources
+    virtualenv_install_with_resources(:using => "python@3")
   end
 
   test do


### PR DESCRIPTION
Fixes #14, but not sure if this is the proper fix in the end. Probably?

@simone989 you did the Python@3 change to `depends_on`, does this look correct to you?