### PR TITLE
Update python reference: @3 -> @3.9

### DIFF
--- a/Formula/unox.rb
+++ b/Formula/unox.rb
@@ -6,7 +6,7 @@ class Unox < Formula
   head 'https://github.com/hnsl/unox.git', :using => :git, :revision => '0.2.0'
   sha256 '163668398356619d0b422f7e067836754d6eae6bf63058bac3f4c7c70182e837'
   revision 1
-  depends_on "python@3"
+  depends_on "python@3.9"
 
   resource 'watchdog' do
     url 'https://pypi.python.org/packages/54/7d/c7c0ad1e32b9f132075967fc353a244eb2b375a3d2f5b0ce612fd96e107e/watchdog-0.8.3.tar.gz'
@@ -21,7 +21,7 @@ class Unox < Formula
   include Language::Python::Virtualenv
 
   def install
-    virtualenv_install_with_resources(:using => "python@3")
+    virtualenv_install_with_resources(:using => "python@3.9")
   end
 
   test do


### PR DESCRIPTION
Homebrew's "python@3" has recently changed its default from 3.9 to 3.10. This change breaks some of unox's underlying dependencies, which rely on collections.MutableSet. 

When I start docker-sync, I see multiple failures that state: `module 'collections' has no attribute 'MutableSet'`. MutableSet was accessible under "collections" in python 3.9, but has been moved to "collections.abc" in python 3.10.